### PR TITLE
Fix for the opengamebenchmarks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An open-source project with the aim of collecting and analysing game performance data in both Linux and Windows
 <br>
-<a href="www.opengamebenchmarks.org" target="new">www.opengamebenchmarks.org</a>
+<a href="http://www.opengamebenchmarks.org" target="new">www.opengamebenchmarks.org</a>
 
 
 <h2>Goals</h2>


### PR DESCRIPTION
The previous version lacked the "http://" part of the link, that produce a error that redirects the link to a non existent file in the GitHub repo.
